### PR TITLE
Allow passing vsce command path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning][semver].
 
 ## [Unreleased]
 
+### Added
+
+- Option to pass _vsce_ command path ([#3])
+
+[#3]: https://github.com/danixeee/textx-gen-vscode/pull/3
+
 ## [0.1.1] - 10/03/2019
 
 ### Added

--- a/textx_gen_vscode/__init__.py
+++ b/textx_gen_vscode/__init__.py
@@ -20,6 +20,7 @@ def vscode_gen(
     description="textX",
     vsix=False,
     skip_keywords=False,
+    vsce="vsce",
 ):
     """Generating VS Code extension for installed textX projects."""
     if not project_name:
@@ -35,4 +36,5 @@ def vscode_gen(
         vsix,
         output_path,
         skip_keywords,
+        vsce,
     )

--- a/textx_gen_vscode/generators.py
+++ b/textx_gen_vscode/generators.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 import jinja2
 from textx import language_descriptions
+
 from textx_gen_coloring.generators import generate_textmate_syntax
 
 this_folder = dirname(__file__)
@@ -75,6 +76,7 @@ def generate_vscode_extension(
     vsix=False,
     output_path="",
     skip_keywords=False,
+    vsce="vsce",
 ):
     """Generate minimal extension from template files and given information.
 
@@ -118,7 +120,7 @@ def generate_vscode_extension(
         # Create installable .vsix file
         if vsix:
             subprocess.run(
-                ["vsce", "package", "-o", "{}.vsix".format(archive_dest)],
+                [vsce, "package", "-o", "{}.vsix".format(archive_dest)],
                 cwd=tmp,
                 stdout=subprocess.DEVNULL,
                 stderr=subprocess.DEVNULL,


### PR DESCRIPTION
Allow passing vsce command path when `vsce` command is not available in system path (e.g. installed locally).